### PR TITLE
fixed indexing constants to use name instead of value

### DIFF
--- a/php/src/Indexer.php
+++ b/php/src/Indexer.php
@@ -571,9 +571,9 @@ class Indexer
             ];
         }
 
-        foreach ($element->getConstants() as $constant) {
-            $rawData['constants'][$constant] = [
-                'name'       => $constant,
+        foreach ($element->getConstants() as $constantName => $constantValue) {
+            $rawData['constants'][$constantName] = [
+                'name'       => $constantName,
                 'startLine'  => null,
                 'docComment' => null
             ];


### PR DESCRIPTION
Constant indexing used constant values instead of names. When constant value was null (i.e. DEFAULT_LOCALE in Locale class from intl extension) it crashed the whole index process.