### PR TITLE
Proxy - Fix spaces in file paths on Windows

### DIFF
--- a/lib/Proxy.coffee
+++ b/lib/Proxy.coffee
@@ -35,15 +35,20 @@ class Proxy
      * @return {array}
     ###
     prepareParameters: (args) ->
+        win = os.type() == "Windows_NT"
+        escapeFunc = if win then Utility.quote else Utility.escapeSpaces
         parameters = [
             '-d memory_limit=-1',
-            Utility.escapeSpaces(__dirname + "/../php/src/Main.php"),
-            Utility.escapeSpaces(@getIndexDatabasePath())
+            escapeFunc(__dirname + "/../php/src/Main.php"),
+            escapeFunc(@getIndexDatabasePath())
         ]
 
         for a in args
-            a = Utility.escapeSeparators(a)
-            a = Utility.escapeSpaces(a)
+            if win
+              a = Utility.quote(a);
+            else
+              a = Utility.escapeSeparators(a)
+              a = Utility.escapeSpaces(a)
 
             parameters.push(a)
 

--- a/lib/Utility.coffee
+++ b/lib/Utility.coffee
@@ -35,3 +35,14 @@ module.exports =
       return '' if not text
 
       return text.replace(/\ /g, '\\ ')
+
+    ###*
+     * Quotes text
+     *
+     * @param {string} text
+     *
+     * @return {string}
+    ###
+    quote: (text) ->
+      return '""' if not text || text.length == 0
+      return '"' + text.replace(/"/g, '""') + '"'


### PR DESCRIPTION
Escaping spaces in command line arguments with slashes doesn't work on Windows.

So I just wrapped all the arguments in quotes.