### PR TITLE
indexing events API implementation proposal

### DIFF
--- a/lib/Service.coffee
+++ b/lib/Service.coffee
@@ -351,7 +351,7 @@ class Service
      * @param   {function} callback
      * @return  {Disposable}
     ###
-    onIndexingFinished: (callback) ->
+    onnDidFinishIndexing: (callback) ->
         delayedCallback = () => setTimeout callback, 10
         @proxy.indexingEventEmitter.on 'php-integrator-base:indexing-finished', delayedCallback
 
@@ -364,6 +364,6 @@ class Service
      * @param   {function} callback
      * @return  {Disposable}
     ###
-    onIndexingFailed: (callback) ->
+    onDidFailIndexing: (callback) ->
         delayedCallback = () => setTimeout callback, 10
         @proxy.indexingEventEmitter.on 'php-integrator-base:indexing-failed', delayedCallback

--- a/lib/Service.coffee
+++ b/lib/Service.coffee
@@ -344,3 +344,26 @@ class Service
         return null if not callStack or callStack.length == 0
 
         return @parser.getResultingTypeFromCallStack(editor, bufferPosition, callStack)
+
+    ###*
+     * Attaches a callback to indexing finished event.
+     *
+     * @param   {function} callback
+     * @return  {Disposable}
+    ###
+    onIndexingFinished: (callback) ->
+        delayedCallback = () => setTimeout callback, 10
+        @proxy.indexingEventEmitter.on 'php-integrator-base:indexing-finished', delayedCallback
+
+    ###*
+     * Attaches a callback to indexing failed event.
+     *
+     * The callback is deferred because immediate call
+     * results in outdated data in service calls.
+     *
+     * @param   {function} callback
+     * @return  {Disposable}
+    ###
+    onIndexingFailed: (callback) ->
+        delayedCallback = () => setTimeout callback, 10
+        @proxy.indexingEventEmitter.on 'php-integrator-base:indexing-failed', delayedCallback

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     }
   },
   "dependencies": {
+    "event-kit": "^2.0.0",
     "fuzzaldrin": "^2.1.0",
     "jquery": "~2.1.4",
     "md5": "~2.0.0"


### PR DESCRIPTION
As discussed in  #58, this is my proposal of the indexing events API implementation:

* events are handled by event-kit (introduced a new dependency, sorry)
* the service now has two public event hooks: onDidFinishIndexing and onDidFailIndexing (accordingly to Atom conventions) which return Disposables
* events are fired in Proxy's performRequestSync and performRequestAsync
* event handlers are slightly deferred to ensure data is not outdated

Problems:
* indexing-finished event firing should be debounced - I tested this version in php-integrator-symbol-viewer and the event is triggered 2 or 3 times within ~50ms, which is not horrible, but anyway should be improved