### PR TITLE
Main - Fixed symlink directory being wrong project source

### DIFF
--- a/lib/Main.coffee
+++ b/lib/Main.coffee
@@ -109,7 +109,7 @@ module.exports =
         if isProjectIndex
             console.time(timerName);
 
-            fileName = atom.project.getDirectories()[0]?.path
+            fileName = atom.project.getDirectories()[0]?.realPath
 
             if @statusBarManager
                 @statusBarManager.setLabel("Indexing...")


### PR DESCRIPTION
Small fix to use the real path instead of the symlink path, as none of the features were working.

On my computer I have a symlink from `~/Development` to `/var/www`. By doing this it meant when it indexes the project, the --source is `/home/{username}/Development/{project}` and not `/var/www/{project}`

But when you go to get the class list...etc it uses `editor.getPath()` which seems to return the real path. 

I haven't tested this on anything but my Linux machine so not sure if this effects anything with Windows.

Hope this makes sense.

Thanks Chris

