### PR TITLE
Set default PHP timezone

### DIFF
--- a/php/src/Main.php
+++ b/php/src/Main.php
@@ -5,6 +5,11 @@ use PhpIntegrator\Application;
 // Show us pretty much everything so we can properly debug what is going wrong.
 error_reporting(E_ALL & ~E_DEPRECATED);
 
+// If not timezone is set, default to `UTC` to prevent warnings in PHP 5.3+
+if (! ini_get('date.timezone')) {
+    date_default_timezone_set('UTC');
+}
+
 // This limit can pose a problem for NameResolver built-in to php-parser (it can go over a nesting level of 300 in e.g.
 // a Symfony2 code base). Also, -1 as a value doesn't work in some setups, see also:
 // https://github.com/Gert-dev/php-integrator-base/issues/91


### PR DESCRIPTION
It would be nice if a default PHP timezone is set, so no editing of ini-files is necessary to get this package up and running.

In issue #57 it was decided to not set a default timezone, **however** PHP sets the default timezone to `UTC` anyhow when if it throws the error.

```
DateTime::__construct(): It is not safe to rely on the system's timezone settings.
You are *required* to use the date.timezone setting or the date_default_timezone_set() function.
In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier.
We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone.
```

So I don't see an issue why `UTC` could not be set as default timezone (_as long as no timezone is set_).