### PR TITLE
Suppressing CircularDependencyException on dependencies

### DIFF
--- a/php/src/Indexer.php
+++ b/php/src/Indexer.php
@@ -329,8 +329,12 @@ class Indexer
                 $topologicalSorter->add($fqsen, $filename, $dependencyList);
             }
         }
-
-        $sortedDependencies = $topologicalSorter->sort();
+        
+        try {
+            $sortedDependencies = $topologicalSorter->sort();
+        } catch (\Exception  $e) {
+            //some kind of warning would be nice
+        }
 
         foreach ($topologicalSorter->getGroups() as $group) {
             $result[] = $group->type;


### PR DESCRIPTION
Adding try catch around TopSort sort call. This still allowed me to use the plugin and index my project. I do not know what is missed by trapping this, but the plugin actually works for me now. This is in regards to https://github.com/Gert-dev/php-integrator-base/issues/136