### PR TITLE
check arguments exist before checking value

### DIFF
--- a/php/src/Application/Command/Reindex.php
+++ b/php/src/Application/Command/Reindex.php
@@ -100,8 +100,8 @@ class Reindex extends AbstractCommand
             isset($arguments['stdin']),
             isset($arguments['verbose']),
             isset($arguments['stream-progress']),
-            isset($arguments['exclude']->value) ? $arguments['exclude']->value : [],
-            isset($arguments['extension']->value) ? $arguments['extension']->value : []
+            isset($arguments['exclude'], $arguments['exclude']->value) ? $arguments['exclude']->value : [],
+            isset($arguments['extension'], $arguments['extension']->value) ? $arguments['extension']->value : []
         );
 
         return $this->outputJson($success, []);


### PR DESCRIPTION
otherwise it throws an error when there is no exclude